### PR TITLE
Addition of LAPIS-based links and reversion columns

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ lineage_params:
   distinction: 1 #minimum mutation weight. Default weighting scheme is 1 per mutation (more for mutations associated with immune escape if escape_weighting is used).
   recursive: False #allow proposal of additional sublineages from newly proposed lineages. Can break links for recursively proposed lineage issue output.
   cutoff: 0.99 #stop adding new serial (exclusive) lineage annotations when this percentage of samples is labeled.
-  earliest_date: '2022-10-15' #ignore all samples before this date. Set to 2019-12-01 to examine the entire pandemic.
+  earliest_date: '2022-12-10' #ignore all samples before this date. Set to 2019-12-01 to examine the entire pandemic.
   downloadable_samples: 10 #include this many samples in the download link for getting representative genome sequences in FASTA format.
   weight_params:
     escape_weighting: 0 #Higher values means mutations associated with immune escape by the Bloom lab DMS are given higher weight. Set to 0 to disable escape weighting. 
@@ -25,13 +25,13 @@ issue_params:
   local_only: True #set to True to print markdown issues to local files instead of attempting to post them to the repository issues board.
 request_params:
   designation_repo: "../auto-pango-designation" #path to a local clone of https://github.com/cov-lineages/pango-designation or one of its forks. Required for pull request generation.
-  local_only: True #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
+  local_only: False #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
   auto_merge: False #immediately merge the generated pull request, if your api_key has permissions.
   representative_number: 1000 #add up to this many lineage representative samples per lineage to lineages.csv.
   valid_samples: "None" #use samples from this file when expanding lineages.csv. Set to "None" to use any samples from the tree.
   countries: 1 #set a minimum number of countries a lineage must exist in to be included in the request.
   maximum: 25 #set a maximum number of lineages to include in a pull request. The top N are sorted by stratified growth.
-  active_since: '2022-12-01' #only include lineage proposals that were actively sampled since the indicated date. Set to "None" to report all.
+  active_since: '2022-2-01' #only include lineage proposals that were actively sampled since the indicated date. Set to "None" to report all.
   samples_different: 5 #block sublineage proposals that are less than this many samples different from the parent lineage. Set this higher to block proposals that constitute the vast majority of the parent lineage. Set to 0 to disable this filter. 
   growth_model: #parameters to adjust the behavior of the inferred growth model.
     use_model: True #set to True to infer the model, applying the parameters below, and add to the results table.

--- a/config.yaml
+++ b/config.yaml
@@ -13,10 +13,11 @@ lineage_params:
   recursive: False #allow proposal of additional sublineages from newly proposed lineages. Can break links for recursively proposed lineage issue output.
   cutoff: 0.99 #stop adding new serial (exclusive) lineage annotations when this percentage of samples is labeled.
   earliest_date: '2022-10-15' #ignore all samples before this date. Set to 2019-12-01 to examine the entire pandemic.
+  downloadable_samples: 10 #include this many samples in the download link for getting representative genome sequences in FASTA format.
   weight_params:
     escape_weighting: 0 #Higher values means mutations associated with immune escape by the Bloom lab DMS are given higher weight. Set to 0 to disable escape weighting. 
     country_weighting: 10 #Higher values means samples from underrepresented countries count more. Set to 0 to disable country weighting. 
-reporting_params:
+issue_params:
   sort_by: "proposed_sublineage_score" #sort the results by this column.
   number: 20 #report the top X lineages in issues.
   prefix: "proposed_" #set a prefix for markdown and associated file output.
@@ -24,7 +25,7 @@ reporting_params:
   local_only: True #set to True to print markdown issues to local files instead of attempting to post them to the repository issues board.
 request_params:
   designation_repo: "../auto-pango-designation" #path to a local clone of https://github.com/cov-lineages/pango-designation or one of its forks. Required for pull request generation.
-  local_only: False #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
+  local_only: True #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
   auto_merge: False #immediately merge the generated pull request, if your api_key has permissions.
   representative_number: 1000 #add up to this many lineage representative samples per lineage to lineages.csv.
   valid_samples: "None" #use samples from this file when expanding lineages.csv. Set to "None" to use any samples from the tree.

--- a/config.yaml
+++ b/config.yaml
@@ -1,42 +1,43 @@
-escape_data: "./SARS2_RBD_Ab_escape_maps/processed_data/escape_data.csv"
-reference_genome: "./reference/NC_045512v2.fa"
-reference_gtf: "./reference/ncbiGenes.noORF1a.gtf"
-genbank: "./reference/hu1.gb"
-python: /home/jakob/anaconda3/envs/newusher/bin/python3.8 #path or name for a specific Python interpreter to use.
-lineage_params:
-  floor: 3 #minimum score value. Set higher to filter smaller and less valuable proposals. Set to 0 to report any and all sublineage proposals that pass other filters.
-  annotation: B.1.1.529 #consider only this lineage and its descendents for sublineage proposal. Set to None to consider all lineages. 
-  missense: True #consider only mutations that lead to amino acid changes as part of the haplotype. 
-  gene: None #consider only mutations within the indicated gene as part of the haplotype. Set to None to use the whole genome.
-  minsamples: 10 #minimum sample weight. Default weighting scheme is 1 per sample (more for underrepresented countries when country_weighting is used).
-  distinction: 1 #minimum mutation weight. Default weighting scheme is 1 per mutation (more for mutations associated with immune escape if escape_weighting is used).
-  recursive: False #allow proposal of additional sublineages from newly proposed lineages. Can break links for recursively proposed lineage issue output.
-  cutoff: 0.99 #stop adding new serial (exclusive) lineage annotations when this percentage of samples is labeled.
-  earliest_date: '2022-12-10' #ignore all samples before this date. Set to 2019-12-01 to examine the entire pandemic.
-  downloadable_samples: 10 #include this many samples in the download link for getting representative genome sequences in FASTA format.
-  weight_params:
-    escape_weighting: 0 #Higher values means mutations associated with immune escape by the Bloom lab DMS are given higher weight. Set to 0 to disable escape weighting. 
-    country_weighting: 10 #Higher values means samples from underrepresented countries count more. Set to 0 to disable country weighting. 
+escape_data: ./SARS2_RBD_Ab_escape_maps/processed_data/escape_data.csv
+genbank: ./reference/hu1.gb
 issue_params:
-  sort_by: "proposed_sublineage_score" #sort the results by this column.
-  number: 20 #report the top X lineages in issues.
-  prefix: "proposed_" #set a prefix for markdown and associated file output.
-  samples_named: 15 #name up to this many samples within the text of the report, including the oldest and youngest samples. 
-  local_only: True #set to True to print markdown issues to local files instead of attempting to post them to the repository issues board.
+  local_only: true
+  number: 20
+  prefix: proposed_
+  samples_named: 15
+  sort_by: proposed_sublineage_score
+lineage_params:
+  annotation: B.1.1.529
+  cutoff: 0.99
+  distinction: 1
+  downloadable_samples: 10
+  earliest_date: 2022-12-20
+  floor: 3
+  gene: None
+  minsamples: 10
+  missense: true
+  recursive: false
+  weight_params:
+    country_weighting: 10
+    escape_weighting: 0
+python: /home/jakob/anaconda3/envs/newusher/bin/python3.8
+reference_genome: ./reference/NC_045512v2.fa
+reference_gtf: ./reference/ncbiGenes.noORF1a.gtf
 request_params:
-  designation_repo: "../auto-pango-designation" #path to a local clone of https://github.com/cov-lineages/pango-designation or one of its forks. Required for pull request generation.
-  local_only: False #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
-  auto_merge: False #immediately merge the generated pull request, if your api_key has permissions.
-  representative_number: 1000 #add up to this many lineage representative samples per lineage to lineages.csv.
-  valid_samples: "None" #use samples from this file when expanding lineages.csv. Set to "None" to use any samples from the tree.
-  countries: 1 #set a minimum number of countries a lineage must exist in to be included in the request.
-  maximum: 25 #set a maximum number of lineages to include in a pull request. The top N are sorted by stratified growth.
-  active_since: '2022-2-01' #only include lineage proposals that were actively sampled since the indicated date. Set to "None" to report all.
-  samples_different: 5 #block sublineage proposals that are less than this many samples different from the parent lineage. Set this higher to block proposals that constitute the vast majority of the parent lineage. Set to 0 to disable this filter. 
-  growth_model: #parameters to adjust the behavior of the inferred growth model.
-    use_model: True #set to True to infer the model, applying the parameters below, and add to the results table.
-    draws: 1000 #set the drawing parameter for the sampler. https://www.pymc.io/projects/docs/en/stable/api/generated/pymc.sample.html
-    tune: 1500 #set the tuning parameter for the sampler.
-    target_accept: 0.9 #set the target acceptance parameter for the sampler.
-    min_country_weeks: 2 #require this many total data points, as combinations of countries and weeks. 
-    max_proportion_considered: .1 #ignore datapoints at a higher proportion than this for being unlikely to behave exponentially or exhibiting other issues.
+  active_since: 2023-02-07
+  auto_merge: false
+  countries: 1
+  designation_repo: ../auto-pango-designation
+  growth_model:
+    draws: 1000
+    max_proportion_considered: 0.1
+    min_country_weeks: 2
+    target_accept: 0.9
+    tune: 1500
+    use_model: false
+  local_only: true
+  maximum: 20
+  representative_number: 1000
+  samples_different: 5
+  valid_samples: None
+  no_prefix: true

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ escape_data: "./SARS2_RBD_Ab_escape_maps/processed_data/escape_data.csv"
 reference_genome: "./reference/NC_045512v2.fa"
 reference_gtf: "./reference/ncbiGenes.noORF1a.gtf"
 genbank: "./reference/hu1.gb"
-python: python #path or name for a specific Python interpreter to use.
+python: /home/jakob/anaconda3/envs/newusher/bin/python3.8 #path or name for a specific Python interpreter to use.
 lineage_params:
   floor: 3 #minimum score value. Set higher to filter smaller and less valuable proposals. Set to 0 to report any and all sublineage proposals that pass other filters.
   annotation: B.1.1.529 #consider only this lineage and its descendents for sublineage proposal. Set to None to consider all lineages. 
@@ -23,8 +23,8 @@ reporting_params:
   samples_named: 15 #name up to this many samples within the text of the report, including the oldest and youngest samples. 
   local_only: True #set to True to print markdown issues to local files instead of attempting to post them to the repository issues board.
 request_params:
-  designation_repo: "./auto-pango-designation" #path to a local clone of https://github.com/cov-lineages/pango-designation or one of its forks. Required for pull request generation.
-  local_only: True #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
+  designation_repo: "../auto-pango-designation" #path to a local clone of https://github.com/cov-lineages/pango-designation or one of its forks. Required for pull request generation.
+  local_only: False #update local files and print the text for a pull request body to a local markdown file instead of opening a branch and pull request on the targeted repository.
   auto_merge: False #immediately merge the generated pull request, if your api_key has permissions.
   representative_number: 1000 #add up to this many lineage representative samples per lineage to lineages.csv.
   valid_samples: "None" #use samples from this file when expanding lineages.csv. Set to "None" to use any samples from the tree.

--- a/flag_lineages.smk
+++ b/flag_lineages.smk
@@ -54,10 +54,10 @@ rule write_issues:
     output:
         "{tree}.issues.log"
     run:
-        if eval(str(config["reporting_params"]["local_only"])):
-            shell("{config[python]} write_issues.py --local -i {input[0]} -t {input[1]} -m {input[2]} -n {config[reporting_params][number]} -s {config[reporting_params][sort_by]} -p {config[reporting_params][prefix]} -c {config[reporting_params][samples_named]}")
+        if eval(str(config["issue_params"]["local_only"])):
+            shell("{config[python]} write_issues.py --local -i {input[0]} -t {input[1]} -m {input[2]} -n {config[issue_params][number]} -s {config[issue_params][sort_by]} -p {config[issue_params][prefix]} -c {config[issue_params][samples_named]}")
         else:
-            shell("{config[python]} write_issues.py -i {input[0]} -t {input[1]} -m {input[2]} -n {config[reporting_params][number]} -s {config[reporting_params][sort_by]} -p {config[reporting_params][prefix]} -c {config[reporting_params][samples_named]}")
+            shell("{config[python]} write_issues.py -i {input[0]} -t {input[1]} -m {input[2]} -n {config[issue_params][number]} -s {config[issue_params][sort_by]} -p {config[issue_params][prefix]} -c {config[issue_params][samples_named]}")
 
 rule add_metadata:
     input:
@@ -76,7 +76,7 @@ rule generate_report:
     output:
         "{tree}.proposed.report.tsv"
     shell:
-        "{config[python]} generate_lineage_report.py -i {input[0]} -p {input[1]} -o {output} -f {config[reference_genome]} -g {config[reference_gtf]} -m {input[2]} -d {config[lineage_params][earliest_date]}"
+        "{config[python]} generate_lineage_report.py -i {input[0]} -p {input[1]} -o {output} -f {config[reference_genome]} -g {config[reference_gtf]} -m {input[2]} -d {config[lineage_params][earliest_date]} -r {config[lineage_params][downloadable_samples]}"
 
 rule propose:
     input:
@@ -194,5 +194,4 @@ rule collect_node_statistics:
         #at some point these should be resolved and UShER/matUtils can be added to the env.yml. 
         "usher.yml"
     shell:
-        "matUtils summary -i {input} -N {output}" #eventually.
-        # "matUtils extract -i {input} --node-stats {output}"
+        "matUtils summary -i {input} -N {output}"

--- a/flag_lineages.smk
+++ b/flag_lineages.smk
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, Path(workflow.basedir).parent.as_posix())
 import pandas as pd
 import datetime as dt
 import numpy as np
@@ -91,7 +90,7 @@ rule propose:
     run:
         d = {"input":input[0]}
         for k,v in config['lineage_params'].items():
-            if k == 'weight_params' or k == 'earliest_date':
+            if k == 'weight_params' or k == 'earliest_date' or k == 'downloadable_samples':
                 continue #these are used elsewhere.
             if v in ['None','True','False']:
                 d[k] = eval(v)

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -210,7 +210,10 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
             else:
                 for m in n.mutations:
                     allm.add(m)
-        return ",".join(reversions)
+        if len(reversions) > 0:
+            return ",".join(reversions)
+        else:
+            return "No Reversions"
     pdf['reversions'] = pdf.proposed_sublineage_nid.apply(get_reversions)
     def get_mset(mutations):
         mhap = []

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -189,7 +189,6 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 #further filter aa changes in orf1a/b so that they're properly processed for taxonium viewing and not counted redundantly
                 #in our code, ORF1a changes are annotated as both ORF1a and ORF1ab, ORF1b are annotated as ORF1ab only.
                 alla = translation.get(n.id,[])
-                spikes = [a.aa_index for a in alla if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa]
                 if n.id == row.parent_nid:
                     past_parent = True
                 if past_parent:
@@ -198,8 +197,8 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 #all mutations along the path contribute to the child lineage haplotype.
                 child_aas = update_aa_haplotype(child_aas, alla)
             hstr = ",".join([aa.aa_string() for aa in child_aas])
-            child_escape = calculator.binding_retained(child_aas)
-            parent_escape = calculator.binding_retained(parent_aas)
+            child_escape = calculator.binding_retained([a.index for a in child_aas if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa])
+            parent_escape = calculator.binding_retained([a.index for a in parent_aas if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa])
             net_escape_gain = parent_escape - child_escape
             hstrs.append(hstr)
             cev.append(child_escape)

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -132,7 +132,7 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
             hapstring.append(",".join(n.mutations))
         return ">".join(hapstring[::-1])
     pdf['mutations'] = pdf.apply(get_separating_mutations,axis=1)
-    def get_representative_download(row, total = 10):
+    def get_representative_download(row):
         possible = t.get_leaves_ids(row.proposed_sublineage_nid)
         count = 0
         gbv = []
@@ -140,20 +140,20 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
             try:
                 gb = mdf.loc[l].genbank_accession
                 gbv.append(gb)
-                total += 1
+                count += 1
             except KeyError:
                 continue
-            if count >= total:
+            if count >= downloadcount:
                 break
-        if len(gbv) < total and len(gbv) > 0:
-            print(f"WARNING: Less than {total} samples in lineage {row.proposed_sublineage} have genbank accessions for download. Using {len(gbv)} samples instead")
+        if len(gbv) < downloadcount and len(gbv) > 0:
+            print(f"WARNING: Less than {downloadcount} samples in lineage {row.proposed_sublineage} have genbank accessions for download. Using {len(gbv)} samples instead")
             return "https://lapis.cov-spectrum.org/open/v1/sample/fasta?genbankAccession=" + ','.join(gbv)
         elif len(gbv) == 0:
             print(f"WARNING: No samples in lineage {row.proposed_sublineage} have associated accessions!")
             return np.nan
         else:
             return "https://lapis.cov-spectrum.org/open/v1/sample/fasta?genbankAccession=" + ','.join(gbv)
-    pdf['seqlink'] = pdf.apply(get_representative_download,downloadcount,axis=1)
+    pdf['seqlink'] = pdf.apply(get_representative_download,axis=1)
     def get_growth_score(row):
         try:
             td = (row.latest_child - row.earliest_child)

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -196,8 +196,8 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
             mhap = []
             locs = set()
             for mset in reversed(row.mutations.split(">")):
-                for m in mset:
-                    location = int(mset)
+                for m in mset.split(','):
+                    location = int(m[1:-1])
                     if location not in locs:
                         locs.add(location)
                         mhap.append(m[1:])

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -223,10 +223,15 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 print(f"WARNING: Lapis Error Status Code {response.status_code} for link {check_query}")
                 return np.nan
             epi_isl_list = []
+            count = 0
             for d in response.json()['data']:
                 v = d.get("gisaidEpiIsl",None)
                 if v != None:
+                    count += 1
                     epi_isl_list.append(v)
+                    #don't save more than 10 epi isls.
+                    if count > 10:
+                        break
             return ",".join(epi_isl_list)
         pdf['epi_isls'] = pdf.apply(get_epi_isls,axis=1)
         def changes_to_list(aacstr):

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -217,22 +217,8 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 return f"https://lapis.cov-spectrum.org/open/v1/sample/fasta?pangoLineage={row.parent}&nucMutations={row.mset}"
         pdf['seqlink'] = pdf.apply(get_representative_download,axis=1)
         def get_epi_isls(row):
-            query = f"https://lapis.cov-spectrum.org/open/v1/sample/details?pangoLineage={row.parent}&nucMutations={row.mset}"
-            response = requests.get(query)
-            if response.status_code != requests.codes.ok:
-                print(f"WARNING: Lapis Error Status Code {response.status_code} for link {check_query}")
-                return np.nan
-            epi_isl_list = []
-            count = 0
-            for d in response.json()['data']:
-                v = d.get("gisaidEpiIsl",None)
-                if v != None:
-                    count += 1
-                    epi_isl_list.append(v)
-                    #don't save more than 10 epi isls.
-                    if count > 10:
-                        break
-            return ",".join(epi_isl_list)
+            query = f"https://lapis.cov-spectrum.org/open/v1/sample/gisaid-epi-isl?pangoLineage={row.parent}&nucMutations={row.mset}&host=Human&accessKey=9Cb3CqmrFnVjO3XCxQLO6gUnKPd"
+            return query
         pdf['epi_isls'] = pdf.apply(get_epi_isls,axis=1)
         def changes_to_list(aacstr):
             changes = []

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -211,7 +211,7 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 return np.nan
             else:
                 #return the fasta download version of this link.
-                return f"https://lapis.cov-spectrum.org/open/v1/sample/fasta?pangoLineage={row.parent}&aaMutations={','.join(list(row.aav))}"
+                return f"https://lapis.cov-spectrum.org/open/v1/sample/fasta?pangoLineage={row.parent}&nucMutations={','.join(mhap)}"
         pdf['seqlink'] = pdf.apply(get_representative_download,axis=1)
         def changes_to_list(aacstr):
             changes = []

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -49,7 +49,10 @@ def write_taxonium_url(parentlin, mutations):
         searchbase['subspecs'].append({"key":key,"type":"genotype","method":"genotype","text":"","gene":gene,"position":loc,"new_residue":state,"min_tips":0})
     searchbase['boolean_method'] = 'and'
     queries = parse.urlencode([("srch",'[' + "".join(str(searchbase).split()).replace("'",'"') + ']'),("enabled",'{"aa1":"true"}'),("zoomToSearch",0)])
-    return urlbase + queries
+    final = urlbase + queries
+    if len(final) > 2000:
+        return "Taxonium link could not be generated- too many characters."
+    return final
 
 def update_aa_haplotype(caas, naas):
     #add all amino acid mutations in naas (new amino acids) to caas (current amino acids) if they don't overlap with an existing protein index.

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -17,7 +17,7 @@ def argparser():
     parser.add_argument("-f", "--reference", default=None, help="Path to a reference fasta file. Use with -g to annotate amino acid changes and immune escape in the expanded output.")
     parser.add_argument("-g", "--gtf", default=None, help="Path to a reference gtf file. Use with -f to annotate amino acid changes and immune escape in the expanded output.")
     parser.add_argument("-d", "--date", default=None, help="Ignore individual samples from before this date when computing reports. Format as %Y-%m-%d")
-    parser.add_argument("-r", "--downloadable_representative", default=10, help="Include up to this many samples in the representative sequence download link.")
+    parser.add_argument("-r", "--downloadable_representative", type=int, default=10, help="Include up to this many samples in the representative sequence download link.")
     args = parser.parse_args()
     return args
 

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -217,7 +217,9 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 return f"https://lapis.cov-spectrum.org/open/v1/sample/fasta?pangoLineage={row.parent}&nucMutations={row.mset}"
         pdf['seqlink'] = pdf.apply(get_representative_download,axis=1)
         def get_epi_isls(row):
-            query = f"https://lapis.cov-spectrum.org/open/v1/sample/gisaid-epi-isl?pangoLineage={row.parent}&nucMutations={row.mset}&host=Human&accessKey=9Cb3CqmrFnVjO3XCxQLO6gUnKPd"
+            #open version for if we ever have problems with the queries
+            #query = f"https://lapis.cov-spectrum.org/open/v1/sample/gisaid-epi-isl?pangoLineage={row.parent}&nucMutations={row.mset}"
+            query = f"https://lapis.cov-spectrum.org/gisaid/v1/sample/gisaid-epi-isl?pangoLineage={row.parent}&nucMutations={row.mset}&accessKey=9Cb3CqmrFnVjO3XCxQLO6gUnKPd"
             return query
         pdf['epi_isls'] = pdf.apply(get_epi_isls,axis=1)
         def changes_to_list(aacstr):

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -197,8 +197,8 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
                 #all mutations along the path contribute to the child lineage haplotype.
                 child_aas = update_aa_haplotype(child_aas, alla)
             hstr = ",".join([aa.aa_string() for aa in child_aas])
-            child_escape = calculator.binding_retained([a.index for a in child_aas if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa])
-            parent_escape = calculator.binding_retained([a.index for a in parent_aas if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa])
+            child_escape = calculator.binding_retained([a.aa_index for a in child_aas if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa])
+            parent_escape = calculator.binding_retained([a.aa_index for a in parent_aas if a.gene == 'S' and a.aa_index in calculator.sites and a.original_aa != a.alternative_aa])
             net_escape_gain = parent_escape - child_escape
             hstrs.append(hstr)
             cev.append(child_escape)

--- a/generate_lineage_report.py
+++ b/generate_lineage_report.py
@@ -139,8 +139,9 @@ def fill_output_table(t,pdf,mdf,fa_file=None,gtf_file=None,mdate=None,downloadco
         for l in possible:
             try:
                 gb = mdf.loc[l].genbank_accession
-                gbv.append(gb)
-                count += 1
+                if type(gb) == str:
+                    gbv.append(gb)
+                    count += 1
             except KeyError:
                 continue
             if count >= downloadcount:

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -199,11 +199,11 @@ def main():
         return ",".join(list(childhap.difference(parenthap)))
     pdf['Nucleotide Changes'] = pdf.apply(get_mutation_set,axis=1)
     pdf['Lineage Name'] = pdf.proposed_sublineage.apply(compress_lineage)
-    targets = ['Lineage Name', 'parent', 'proposed_sublineage_size','earliest_child','latest_child','Regions','Nucleotide Changes','link','taxlink','Download Open Sequence FASTA','EPI ISLs','aav']
+    targets = ['Lineage Name', 'parent', 'proposed_sublineage_size','earliest_child','latest_child','Regions','Nucleotide Changes','link','taxlink','Download Open Sequence FASTA','EPI ISLs','aav', 'reversions']
     if "Exponential Growth Coefficient CI" in pdf.columns:
         targets.insert(3,'Exponential Growth Coefficient CI')
     pdf = pdf[targets]
-    pdf = pdf.rename({"parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)","aav":"Amino Acid Changes"},axis=1)
+    pdf = pdf.rename({"parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)","aav":"Amino Acid Changes",'reversions':"Nucleotide Reversions"},axis=1)
     if args.output_report != None:
         pdf.to_csv(args.output_report,index=False,sep='\t')
     if not args.local:

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -92,7 +92,7 @@ def write_note(row):
         outstr.append(", defined by " + ", ".join(aastr))
     if len(cstr) > 0:
         outstr.append(", found in " + cstr)
-    outstr.append(". Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.")
+    outstr.append(". Automatically inferred by https://github.com/jmcbroome/autolin.")
     return ''.join(outstr)
 
 def get_reps(nid, t, target = 5000, allowed = set()):
@@ -106,7 +106,7 @@ def get_reps(nid, t, target = 5000, allowed = set()):
 
 def open_pr(branchname,trepo,automerge,reqname,pdf):
     g = Github(os.getenv("API_KEY"))
-    repo = g.get_user().get_repo("auto-pango-designation")
+    repo = g.get_user().get_repo("pango-designation")
     sb = repo.get_branch("master")
     if branchname not in [b.name for b in repo.get_branches()]:
         repo.create_git_ref(ref='refs/heads/' + branchname, sha=sb.commit.sha)
@@ -174,6 +174,7 @@ def main():
         growd = get_growth_model(mdf, args.min_country_weeks, args.target_accept, args.tune, args.draws)
         pdf['Exponential Growth Coefficient CI'] = pdf.proposed_sublineage.apply(lambda x:growd.get(x,(np.nan,np.nan))) 
         pdf['Minimum Growth'] = pdf['Exponential Growth Coefficient CI'].apply(lambda x:x[0])
+        pdf['Exponential Growth Coefficient CI'] = pdf['Exponential Growth Coefficient CI'].astype(str)
         pdf = pdf.sort_values("Minimum Growth",ascending=False)
     pdf = pdf.head(args.maximum)
     allowed = set()

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -190,12 +190,7 @@ def main():
         elif len(epi_isls) == 0:
             return "No Data Available"
         else:
-            #use html tags to format as markdown dropdown table.
-            md = ["<details>\n<summary>Example EPI ISLs</summary>\n"]
-            for ei in epi_isls.split(","):
-                md.append(ei+'\n')
-            md.append('</details>')
-            return "".join(md)
+            return f"[Get EPI ISLs]({epi_isls})"
     pdf['EPI ISLs'] = pdf.epi_isls.apply(make_epi_isl_table)
     pdf['Regions'] = pdf.apply(get_region_summary,axis=1)
     def get_mutation_set(row):

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -73,7 +73,7 @@ def get_region_summary(row):
 def write_note(row):
     unalias = global_aliasor.uncompress(row.proposed_sublineage[5:])
     cstr = get_region_summary(row)
-    aastr = row.aav
+    aastr = row.aav.split(",")
     outstr = ['auto.' + compress_lineage(unalias) + "\t", "Alias of auto." + unalias]
     if len(aastr) > 0:
         outstr.append(", defined by " + ", ".join(aastr))

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -198,11 +198,12 @@ def main():
         parenthap = t.get_haplotype(row.parent_nid)
         return ",".join(list(childhap.difference(parenthap)))
     pdf['Nucleotide Changes'] = pdf.apply(get_mutation_set,axis=1)
-    targets = ['proposed_sublineage', 'parent', 'proposed_sublineage_size','earliest_child','latest_child','Regions','Nucleotide Changes','link','taxlink','Download Open Sequence FASTA','EPI ISLs','aav']
+    pdf['Lineage Name'] = pdf.proposed_sublineage.apply(compress_lineage)
+    targets = ['Lineage Name', 'parent', 'proposed_sublineage_size','earliest_child','latest_child','Regions','Nucleotide Changes','link','taxlink','Download Open Sequence FASTA','EPI ISLs','aav']
     if "Exponential Growth Coefficient CI" in pdf.columns:
         targets.insert(3,'Exponential Growth Coefficient CI')
     pdf = pdf[targets]
-    pdf = pdf.rename({"proposed_sublineage":"Lineage Name", "parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)","aav":"Amino Acid Changes"},axis=1)
+    pdf = pdf.rename({"parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)","aav":"Amino Acid Changes"},axis=1)
     if args.output_report != None:
         pdf.to_csv(args.output_report,index=False,sep='\t')
     if not args.local:

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -198,7 +198,7 @@ def main():
             return f"[View On Taxonium (Public Samples Only)]({txl})"
     pdf['taxlink'] = pdf.taxlink.apply(format_taxlink)
     def get_lapis_link(seqlink):
-        if seqlink == np.nan:
+        if type(seqlink) != str or seqlink == "nan":
             return "No Data Available"
         else:
             return f"[Download Example Sequence FASTA (LAPIS)]({seqlink})"
@@ -223,6 +223,8 @@ def main():
         targets.insert(3,'Exponential Growth Coefficient CI')
     pdf = pdf[targets]
     pdf = pdf.rename({"parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)","aav":"Amino Acid Changes",'reversions':"Nucleotide Reversions"},axis=1)
+    if args.no_prefix:
+        pdf['Lineage Name'] = pdf['Lineage Name'].apply(lambda x:x.lstrip("auto."))
     if args.output_report != None:
         pdf.to_csv(args.output_report,index=False,sep='\t')
     if not args.local:

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -165,7 +165,7 @@ def main():
         pdf.sort_values("Minimum Growth",ascending=False,inplace=True)
     else:
         print("Skipping modeling...")
-        pdf.sort_values("proposed_sublineage_size",ascending=False,inplace=True)
+        pdf.sort_values("proposed_sublineage_score",ascending=False,inplace=True)
     pdf = pdf.head(args.maximum)
     allowed = set()
     if args.samples != "None" and args.samples != None:
@@ -191,7 +191,7 @@ def main():
             return "No Data Available"
         else:
             #use html tags to format as markdown dropdown table.
-            md = ["<details>\n<summary>EPI ISLs</summary>\n"]
+            md = ["<details>\n<summary>Example EPI ISLs</summary>\n"]
             for ei in epi_isls.split(","):
                 md.append(ei+'\n')
             md.append('</details>')

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -189,7 +189,12 @@ def main():
     pdf = update_lineage_files(pdf, t, args.repository, args.representative, allowed, tannotes)
     pdf['link'] = pdf.link.apply(lambda x:f"[View On Cov-Spectrum]({x})")
     pdf['taxlink'] = pdf.taxlink.apply(lambda x:f"[View On Taxonium (Public Samples Only)]({x})")
-    pdf['seqlink'] = pdf.seqlink.apply(lambda x:f"[Download Example Sequence FASTA (LAPIS)]({x})")
+    def get_lapis_link(seqlink):
+        if seqlink == np.nan:
+            return "No Data Available"
+        else:
+            return f"[Download Example Sequence FASTA (LAPIS)]({x})"
+    pdf['seqlink'] = pdf.seqlink.apply(get_lapis_link)
     pdf['Regions'] = pdf.apply(get_region_summary,axis=1)
     def get_mutation_set(row):
         childhap = t.get_haplotype(row.proposed_sublineage_nid)

--- a/open_pull_request.py
+++ b/open_pull_request.py
@@ -107,7 +107,7 @@ def get_reps(nid, t, target = 5000, allowed = set()):
 
 def open_pr(branchname,trepo,automerge,reqname,pdf):
     g = Github(os.getenv("API_KEY"))
-    repo = g.get_user().get_repo("pango-designation")
+    repo = g.get_user().get_repo("auto-pango-designation")
     sb = repo.get_branch("master")
     if branchname not in [b.name for b in repo.get_branches()]:
         repo.create_git_ref(ref='refs/heads/' + branchname, sha=sb.commit.sha)
@@ -189,6 +189,7 @@ def main():
     pdf = update_lineage_files(pdf, t, args.repository, args.representative, allowed, tannotes)
     pdf['link'] = pdf.link.apply(lambda x:f"[View On Cov-Spectrum]({x})")
     pdf['taxlink'] = pdf.taxlink.apply(lambda x:f"[View On Taxonium (Public Samples Only)]({x})")
+    pdf['seqlink'] = pdf.seqlink.apply(lambda x:f"[Download Example Sequence FASTA (LAPIS)]({x})")
     pdf['Regions'] = pdf.apply(get_region_summary,axis=1)
     def get_mutation_set(row):
         childhap = t.get_haplotype(row.proposed_sublineage_nid)
@@ -196,11 +197,11 @@ def main():
         return ",".join(list(childhap.difference(parenthap)))
     pdf['Nucleotide Changes'] = pdf.apply(get_mutation_set,axis=1)
     pdf['Amino Acid Changes'] = pdf.apply(lambda row: ",".join(get_aa_set(row)),axis=1)
-    targets = ['proposed_sublineage', 'parent', 'proposed_sublineage_size','earliest_child','latest_child','Regions','Nucleotide Changes','Amino Acid Changes','link','taxlink']
+    targets = ['proposed_sublineage', 'parent', 'proposed_sublineage_size','earliest_child','latest_child','Regions','Nucleotide Changes','Amino Acid Changes','link','taxlink','seqlink']
     if "Exponential Growth Coefficient CI" in pdf.columns:
         targets.insert(3,'Exponential Growth Coefficient CI')
     pdf = pdf[targets]
-    pdf = pdf.rename({"proposed_sublineage":"Lineage Name", "parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)"},axis=1)
+    pdf = pdf.rename({"proposed_sublineage":"Lineage Name", "parent":"Parent Lineage", "proposed_sublineage_size":"Size","earliest_child":"Earliest Appearance","latest_child":"Latest Appearance","final_date":"Last Checked","child_regions":"Circulating In","link":"View On Cov-Spectrum","taxlink":"View On Taxonium (Public Samples Only)",'seqlink':"Download Example Sequence FASTA"},axis=1)
     if args.output_report != None:
         pdf.to_csv(args.output_report,index=False,sep='\t')
     if not args.local:

--- a/propose_sublineages.py
+++ b/propose_sublineages.py
@@ -284,7 +284,7 @@ def propose(args):
     #decompress all lineage names.
     annotes = {}
     for k,v in cannotes.items():
-        annotes[aliasor.decompress(k)] = v
+        annotes[global_aliasor.uncompress(k)] = v
     if args.annotation != None:
         if args.clear:
             print("ERROR: Cannot select lineages (-a) while clearing lineages (-c)!")

--- a/propose_sublineages.py
+++ b/propose_sublineages.py
@@ -3,6 +3,8 @@ sys.path.append("~/bin:")
 import bte
 import sys
 import argparse
+from pango_aliasor.aliasor import Aliasor
+global_aliasor = Aliasor()
 
 def process_mstr(mstr):
     """Read a mutation string and return the chromosome, location, reference, and alternate alleles.
@@ -275,7 +277,14 @@ def propose(args):
         dumpf = open(args.dump,'w+')
     if args.clear:
         t.apply_annotations({node.id:[] for node in t.depth_first_expansion()})
-    annotes = t.dump_annotations()        
+    try:
+        cannotes = t.dump_annotations()
+    except:
+        cannotes = t.get_annotations() #replacement function in newer versions of bte
+    #decompress all lineage names.
+    annotes = {}
+    for k,v in cannotes.items():
+        annotes[aliasor.decompress(k)] = v
     if args.annotation != None:
         if args.clear:
             print("ERROR: Cannot select lineages (-a) while clearing lineages (-c)!")

--- a/propose_sublineages.py
+++ b/propose_sublineages.py
@@ -394,6 +394,11 @@ def propose(args):
     if args.output != None:
         annd = {}
         for k,v in annotes.items():
+            try:
+                k = global_aliasor.compress(k)
+            except:
+                print(f"Could not compress lineage {k}")
+                pass
             if v not in annd:
                 annd[v] = []
             if len(annd[v]) == 2:
@@ -407,6 +412,11 @@ def propose(args):
     if args.labels != None:
         labels = {}
         for ann, nid in annotes.items():
+            try:
+                ann = global_aliasor.compress(ann)
+            except:
+                print(f"Could not compress lineage {ann}")
+                pass
             for leaf in t.get_leaves_ids(nid):
                 if leaf not in labels:
                     labels[leaf] = [ann]


### PR DESCRIPTION
Updates, bugfixes, and new columns representing:

1. An immediate download of publicly-available sequences through [LAPIS](https://github.com/GenSpectrum/LAPIS)
2. A download of EPI_ISLs associated with the samples in the lineage, also through LAPIS
3. All specific reversions of mutations with respect to the parent lineage- e.g. if the parent lineage has A123G at some point in its ancestry, and the proposed child lineage has the mutation G123A, then that is tagged as a reversion. A mutation of G123C, or if A213G and G123A both occurred along the child's ancestry only and not the parent's, would not be tagged.